### PR TITLE
fix: duplicate font in build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,6 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets/fonts",
               "src/assets/audio"
             ],
             "styles": ["src/styles.scss"],


### PR DESCRIPTION
Remove the dupllicate fonts in build (both at root level and inside folder `/assets/fonts`.